### PR TITLE
Fix incorrect MIME type being inferred on Win during serving

### DIFF
--- a/server.py
+++ b/server.py
@@ -15,6 +15,14 @@ from backend.notepads import list_notepads, set_notepad, get_notepad, get_defaul
 from backend.prompts import list_prompt_formats
 from backend.settings import get_settings, set_settings
 
+
+if os.name == "nt":
+    # Fix Windows inferring text/plain MIME type for static files
+    # https://stackoverflow.com/questions/59355194/
+    import mimetypes
+    mimetypes.add_type("application/javascript", ".js")
+    mimetypes.add_type("text/css", ".css")
+
 app = Flask("ExUI")
 app.static_folder = 'static'
 api_lock = Lock()


### PR DESCRIPTION
Not sure if the best thing to do, as I didn't have this issue with Exllama v1 UI.  
Without the fix, I'd get the following messages in my browser's console:

```
Loading module from “http://localhost:5000/static/theme.js” was blocked because of a disallowed MIME type (“text/plain”).
```

Source:  
https://stackoverflow.com/questions/59355194/python-flask-error-failed-to-load-module-script-strict-mime-type-checking-i