### PR TITLE
Add auto session naming and context tracking qol features.

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -688,9 +688,12 @@ class ChatBlock {
             let ptps = this.block.meta.prompt_speed.toFixed(2)
             if (this.block.meta.prompt_speed > 50000) ptps = "∞";
 
-            let html = "prompt: " + this.block.meta.prompt_tokens.toFixed(0) + " tokens, " + ptps + " tokens/s";
+            let contextPercent = (this.block.meta.context_tokens / this.block.meta.max_seq_len * 100).toFixed(0);
+            let html = "prompt: " + this.block.meta.prompt_tokens.toFixed(0) + " tokens, " + ptps + " tokens/s ";
             html += " ⁄ ";
-            html += "response: " + this.block.meta.gen_tokens.toFixed(0) + " tokens, " + this.block.meta.gen_speed.toFixed(2) + " tokens/s";
+            html += "response: " + this.block.meta.gen_tokens.toFixed(0) + " tokens, " + this.block.meta.gen_speed.toFixed(2) + " tokens/s ";
+            html += " ⁄ ";
+            html += "context: " + contextPercent + "% full";
             p.innerHTML = html;
             this.textBlock.appendChild(p);
         }

--- a/static/models.js
+++ b/static/models.js
@@ -442,6 +442,8 @@ export class ModelView {
     }
 
     loadModel() {
+        const controller = new AbortController();
+        const signal = controller.signal;
 
         overlay.loadingOverlay.setProgress(0, 1);
         overlay.pageOverlay.setMode("loading");
@@ -456,10 +458,18 @@ export class ModelView {
             }, 10000)
         });
 
+        overlay.loadingOverlay.onCancel = () => {
+            controller.abort();
+            overlay.pageOverlay.setMode();
+            this.error_message = "Loading cancelled";
+            this.updateView();
+        };
+
         let fetchRequest = fetch("/api/load_model", {
             method: "POST",
             headers: { "Content-Type": "application/json", },
-            body: JSON.stringify(packet)
+            body: JSON.stringify(packet),
+            signal: signal
         });
 
         const self = this;

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -45,3 +45,7 @@
     text-align: center;
     line-height: 30px;
 }
+
+.overlay .textbutton {
+    margin-top: 25px;
+}

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -1,4 +1,6 @@
 import * as util from "./util.js";
+import * as controls from "./controls.js";
+import * as globals from "./globals.js";
 
 class PageOverlay {
     constructor() {
@@ -60,6 +62,25 @@ class LoadingOverlay extends Overlay {
 
         this.bar = util.newDiv(null, "progressbar-bar");
         this.box.appendChild(this.bar);
+
+        this.cancelButton = new controls.Button("✖ Cancel", () => {
+            // First call the cancel handler to abort the fetch request
+            if (this.onCancel) this.onCancel();
+            
+            // Then unload the model to release GPU memory
+            fetch("/api/unload_model")
+            .then(response => response.json())
+            .then(json => {
+                if (json.result == "ok") {
+                    globals.g.loadedModelUUID = null;
+                    globals.g.failedModelUUID = null;
+                }
+            });
+        });
+        this.cancelButton.setEnabled(true);
+        this.element.appendChild(this.cancelButton.element);
+        
+        this.onCancel = null;
     }
 
     setProgress(a, b) {


### PR DESCRIPTION
Added 3 small QoL changes:

- automatic session naming (will grab first few words from user's first prompt as a title)
- displays context usage (in %) after prompt/response statistics:

![image](https://github.com/user-attachments/assets/9d40b20d-48d0-4a90-bf48-6a6663474f9d)

- user can cancel model loading process:

![image](https://github.com/user-attachments/assets/11316bca-cee6-4357-a09d-a021bd824b6c)