### PR TITLE
feat: Add model parameter management and UI controls

### DIFF
--- a/static/chat.css
+++ b/static/chat.css
@@ -1,4 +1,3 @@
-
 .session-list {
     background-color: var(--background-color-body);
     display: flex;
@@ -492,7 +491,6 @@
     display: block;
 }
 
-
 .save-btn {
     background-color: var(--button-background);
     font-size: var(--font-size-small);
@@ -563,4 +561,8 @@
 
 .chat-popup action:last-child {
     margin-bottom: 0;
+}
+
+.highlight {
+    font-weight: bold;
 }

--- a/static/chat.js
+++ b/static/chat.js
@@ -512,7 +512,13 @@ class SessionView {
         }
 
         if (response.result == "cancel_pre") {
+            // Handle cancel
+        }
 
+        if (response.result == "refresh_settings") {
+            // Update settings and refresh UI
+            this.chatSettings = response.settings;
+            this.settings.populate();
         }
 
         if (this.stickyScroll) this.scrollToBottom();

--- a/static/controls.css
+++ b/static/controls.css
@@ -1,6 +1,6 @@
 
 .vflex_line {
-    height-min: 32px;
+    min-height: 32px;
 }
 
 .checkbox {

--- a/static/controls.css
+++ b/static/controls.css
@@ -39,6 +39,8 @@
     padding-right: 14px;
     margin-right: 10px;
     display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .textbutton.small {
@@ -164,3 +166,7 @@ input[type="checkbox"]:checked + label:after {
       font-weight: bold;
 }
 
+.highlight-label {
+      font-weight: bold;
+      color: var(--textcolor-head);
+}

--- a/static/models.css
+++ b/static/models.css
@@ -59,7 +59,6 @@
     padding: 20px;
     height: calc(100vh - 40px);
     overflow-y: auto;
-    flex-grow: 1;
 }
 
 .model-view-text {


### PR DESCRIPTION
Add support for reading generation_config.json for model parameters 
Implement model_loaded_callback for parameter updates 
Add UI controls to switch between model and app defaults 
Add visual highlighting for modified parameters
Add new API endpoints for parameter management
Improve session handling of model parameters
Make labels centered for text buttons

![Screenshot (2)](https://github.com/user-attachments/assets/8fb5843a-7f8d-4a36-86b3-29361f971185)

Rationale: quite often models have sampling values recommended by their creators stored in the generation_config.json. I thought it might be useful to be able to aplly this with a click of a button :)